### PR TITLE
Import links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 venv/
+poc_helper.db

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This is a Python-based terminal application for managing and connecting to hosts
 - `PyYAML` for parsing YAML files.
 - `SQLAlchemy` for database operations.
 - `simple-term-menu` for the terminal menu interface.
+- `tabulate` for tabulating data to be printed
 
 ## Installation
 
@@ -46,6 +47,7 @@ This is a Python-based terminal application for managing and connecting to hosts
 
 The application uses SQLite for storing host information. The schema is defined in `models.py` and includes the following fields:
 
+### Hosts Table
 - `id`: Integer, primary key.
 - `hostname`: String, unique, not nullable.
 - `ip_address`: String, not nullable.
@@ -53,6 +55,14 @@ The application uses SQLite for storing host information. The schema is defined 
 - `connection`: String, not nullable.
 - `username`: String, not nullable.
 - `password`: String, not nullable.
+
+### Links Table
+
+- `id` : Integer, primary_key
+- `source_host` : String, not nullable
+- `source_interface` : String, not nullable
+- `destination_host` : String, not nullable
+- `destination_interface` : String, not nullable
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This is a Python-based terminal application for managing and connecting to hosts
 - Import hosts from Ansible YAML inventory files.
 - Connect to hosts via SSH.
 - Simple terminal menu interface.
+- Enable or disable network interfaces.
+- Impair network interfaces with delay, jitter, packet loss, rate limiting, and packet corruption.
 
 ## Requirements
 
@@ -14,7 +16,7 @@ This is a Python-based terminal application for managing and connecting to hosts
 - `PyYAML` for parsing YAML files.
 - `SQLAlchemy` for database operations.
 - `simple-term-menu` for the terminal menu interface.
-- `tabulate` for tabulating data to be printed
+- `tabulate` for tabulating data to be printed.
 
 ## Installation
 
@@ -36,7 +38,31 @@ This is a Python-based terminal application for managing and connecting to hosts
     python main.py
     ```
 
-2. Follow the on-screen menu to import hosts or connect to a host.
+2. Import hosts:
+    - Import YAML:
+        - The application will search for a default YAML file (`ansible-inventory.yml`) in the current directory and `../clab*/` directory.
+        - If the default file is found, you will be prompted to use it. If not, you can specify the path to your YAML file.
+    - Import INI:
+        - The application will search for a default INI file (`ansible-inventory.ini`) in the current directory and parent directory.
+        - If the default file is found, you will be prompted to use it. If not, you can specify the path to your INI file.
+    - Manual import:
+        - You can manually enter host information through the terminal menu.
+
+3. Import links:
+    - The application will search for a default containerlab topology file (`topology.yml`) in the current directory and parent directory.
+    - If the default file is found, you will be prompted to use it. If not, you can specify the path to your topology YAML file.
+    - If not using containerlab, you can still import your topology if described in containerlab yaml format
+
+4. Enable/disable interfaces:
+    - Navigate to "Interface Management" -> "Enable or Disable Interfaces".
+    - Select an interface to enable or disable it.
+
+5. Link impairment:
+    - This will only work for containerlab at this time
+    - Navigate to "Interface Management" -> "Impair Interfaces".
+    - Select a link to view and manage its impairments.
+    - If the link has no impairments, you can set delay, jitter, packet loss, rate limiting, and packet corruption.
+    - If the link has impairments, you can choose to remove them or update the values.
 
 ## File Structure
 
@@ -58,11 +84,17 @@ The application uses SQLite for storing host information. The schema is defined 
 
 ### Links Table
 
-- `id` : Integer, primary_key
-- `source_host` : String, not nullable
-- `source_interface` : String, not nullable
-- `destination_host` : String, not nullable
-- `destination_interface` : String, not nullable
+- `id`: Integer, primary key.
+- `source_host`: String, not nullable.
+- `source_interface`: String, not nullable.
+- `destination_host`: String, not nullable.
+- `destination_interface`: String, not nullable.
+- `jitter`: Float, default 0, not nullable.
+- `latency`: Float, default 0, not nullable.
+- `loss`: Float, default 0, not nullable.
+- `rate`: Float, default 0, not nullable.
+- `corruption`: Float, default 0, not nullable.
+- `state`: String, default 'enabled', not nullable.
 
 ## Contributing
 

--- a/main.py
+++ b/main.py
@@ -4,67 +4,122 @@ import subprocess
 import configparser
 from sqlalchemy.exc import IntegrityError
 from simple_term_menu import TerminalMenu
-from models import Host, session
+from models import Host, session, Link
+from tabulate import tabulate
+
 
 def main_menu():
     """Main menu of the application."""
     #Options presented upon application start
-    options = ["[i] Import Hosts", "[c] Connect to Host", "[e] Exit"]
-    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'))
+    options = ["[i] Import Hosts", "[l] Import Links", "[c] Connect to Host", "[a] View and Run Ansible Playbooks", "[e] Exit"]
+    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'), title="Main Menu")
     menu_entry_index = terminal_menu.show()
     #Conditional statements to determine the next steps
     if menu_entry_index == 0:
         import_hosts_menu()
     elif menu_entry_index == 1:
-        connect_host_menu()
+        import_links_menu()
     elif menu_entry_index == 2:
+        connect_host_menu()
+    elif menu_entry_index == 3:
+        preview_and_run_playbook_menu()
+    elif menu_entry_index == 4:
         exit()
 
 def import_hosts_menu():
     """Menu to import hosts from Ansible inventory or manually add a host."""
     #Options presented upon selecting "Import Hosts"
     options = ["[y] Import from Ansible YAML", "[i] Import from Ansible INI", "[m] Manually add Host", "[b] Back to Main Menu"]
-    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'))
+    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'), title="Import Hosts")
     menu_entry_index = terminal_menu.show()
     #Conditional statements to determine the next steps
-    #If "Import from Ansible YAML" is selected, the import_from_yaml function is called
+    #If "Import from Ansible YAML" is selected, the import_inv_from_yaml function is called
     if menu_entry_index == 0:
-        import_from_yaml()
-    #If "Import from Ansible INI" is selected, the import_from_ini function is called
+        import_inv_from_yaml()
+    #If "Import from Ansible INI" is selected, the import_inv_from_ini function is called
     elif menu_entry_index == 1:
-        # TODO import_from_ini()
-        import_from_ini()
+        # TODO import_inv_from_ini()
+        import_inv_from_ini()
     elif menu_entry_index == 2:
         manually_add_host()
     elif menu_entry_index == 3:
         main_menu()
 
-def import_from_yaml():
+
+def import_links_menu():
+    """Menu to import connections from containerlab topology style YAML."""
+    options = ["[c] Import from Containerlab Topology YAML", "[b] Back to Main Menu"]
+    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'), title="Import Links")
+    menu_entry_index = terminal_menu.show()
+    if menu_entry_index == 0:
+        import_links_from_containerlab()
+    elif menu_entry_index == 1:
+        main_menu()
+
+def import_links_from_containerlab():
+    """Function to import links from a Containerlab topology YAML file."""
+    yaml_file = input("What is the path of your Containerlab topology file? ")
+    try:
+        with open(yaml_file, 'r') as file:
+            data = yaml.safe_load(file)
+            links = data.get('topology', {}).get('links', [])
+            links_added = []
+            for link in links:
+                endpoints = link.get('endpoints', [])
+                if len(endpoints) == 2:
+                    source = endpoints[0].split(':')
+                    destination = endpoints[1].split(':')
+                    if len(source) == 2 and len(destination) == 2:
+                        source_host, source_interface = source
+                        destination_host, destination_interface = destination
+                        new_link = Link(
+                            source_host=source_host,
+                            source_interface=source_interface,
+                            destination_host=destination_host,
+                            destination_interface=destination_interface
+                        )
+                        session.add(new_link)
+                        links_added.append(new_link)
+            session.commit()
+            print(tabulate([[link.source_host, link.source_interface, link.destination_host, link.destination_interface] for link in links_added], headers=["Source Host", "Source Interface", "Destination Host", "Destination Interface"]))
+    except FileNotFoundError:
+        print(f"File {yaml_file} not found.")
+    except yaml.YAMLError as exc:
+        print(f"Error parsing YAML file: {exc}")
+    main_menu()
+
+
+def import_inv_from_yaml():
     """Function to import hosts from an Ansible YAML inventory file."""
     #Name of file to open
-    yaml_file = input("What is the name of your inventory file? ")
+    yaml_file = input("What is the path to your inventory file? ")
     try:
         with open(yaml_file, 'r') as file:
             data = yaml.safe_load(file)
             children = data.get('all', {}).get('children', {})
+            hosts_added = []
             for group, group_data in children.items():
                 vars = group_data.get('vars', {})
                 hosts = group_data.get('hosts', {})
                 for hostname, host_data in hosts.items():
+                    image_type = group
+                    network_os = "junos" if "junos" in image_type else vars.get('ansible_network_os', '')
                     new_host = Host(
                         hostname=hostname,
                         ip_address=host_data.get('ansible_host', ''),
-                        network_os=vars.get('ansible_network_os', ''),
+                        network_os=network_os,
                         connection=vars.get('ansible_connection', ''),
                         username=vars.get('ansible_user', ''),
-                        password=vars.get('ansible_password', '')
+                        password=vars.get('ansible_password', ''),
+                        image_type=image_type
                     )
                     session.add(new_host)
-            #Save chanages to hosts.db
+                    hosts_added.append(new_host)
+            # Save changes to hosts.db
             session.commit()
-            print("Hosts added to the database.")
+            print(tabulate([[host.hostname, host.ip_address, host.network_os, host.connection, host.username, host.password, host.image_type] for host in hosts_added], headers=["Hostname", "IP Address", "Network OS", "Connection", "Username", "Password", "Image Type"]))
     except IntegrityError:
-        #Used to prevent having the same host added to the database
+        # Used to prevent having the same host added to the database
         session.rollback()
         print("Duplicate host found. Rolling back changes.")
     except Exception as e:
@@ -89,7 +144,7 @@ def manually_add_host():
             connection=connection,
             username=username,
             password=password
-        )
+            )
         session.add(new_host)
         session.commit()
         print(f"Host {hostname} added to the database.")
@@ -99,33 +154,32 @@ def manually_add_host():
         print(f"Host {hostname} already exists in the database.")
     main_menu()
 
-def import_from_ini():
+def import_inv_from_ini():
     """Function to import hosts from an Ansible INI inventory file."""
-    ini_file = input("What is the name of your inventory file? ")
-    config = configparser.ConfigParser()
+    ini_file = input("What is the path of your inventory file? ")
+    hosts_added = []
     try:
+        config = ConfigParser()
         config.read(ini_file)
         for section in config.sections():
-            if section.endswith(":vars"):
-                continue  # Skip the vars section
-            vars_section = section + ":vars"
-            vars = config[vars_section] if vars_section in config else {}
-            for item in config.items(section):
-                hostname = item[0].split()[0]
-                host_info = item[1].split()
-                ip_address = host_info[0].split('=')[1] if '=' in host_info[0] else host_info[0]
+            for hostname, ip_address in config.items(section):
+                network_os = "junos" if "junos" in section else section
                 new_host = Host(
                     hostname=hostname,
                     ip_address=ip_address,
-                    network_os=vars.get('ansible_network_os', ''),
-                    connection=vars.get('ansible_connection', ''),
-                    username=vars.get('ansible_user', ''),
-                    password=vars.get('ansible_password', '')
+                    network_os=network_os,
+                    connection=config.get(section, 'ansible_connection', fallback=''),
+                    username=config.get(section, 'ansible_user', fallback=''),
+                    password=config.get(section, 'ansible_password', fallback=''),
+                    image_type=section
                 )
                 session.add(new_host)
+                hosts_added.append(new_host)
+        # Save changes to hosts.db
         session.commit()
-        print("Hosts added to the database.")
+        print(tabulate([[host.hostname, host.ip_address, host.network_os, host.connection, host.username, host.password, host.image_type] for host in hosts_added], headers=["Hostname", "IP Address", "Network OS", "Connection", "Username", "Password", "Image Type"]))
     except IntegrityError:
+        # Used to prevent having the same host added to the database
         session.rollback()
         print("Duplicate host found. Rolling back changes.")
     except Exception as e:
@@ -138,7 +192,7 @@ def connect_host_menu():
     hosts = session.query(Host).all()
     #Create an option in the menu for all hosts and a back option
     options = [f"[{i}] {host.hostname}" for i, host in enumerate(hosts, start=1)] + ["[b] Back to Main Menu"]
-    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'))
+    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'), title="Connect to Host")
     menu_entry_index = terminal_menu.show()
     #Logic to initiate connect to host or go back to main menu with a dynamic amount of options
     if menu_entry_index == len(options) - 1:
@@ -161,6 +215,46 @@ def connect_to_host(hostname):
             print(f"Failed to connect: {e}")
     else:
         print(f"Host {hostname} not found in the database.")
+    main_menu()
+
+def list_files(directory="."):
+    return (file for file in os.listdir(directory) if os.path.isfile(os.path.join(directory, file)))
+
+def preview_and_run_playbook_menu():
+    """Menu to preview files and run ansible-playbook."""
+    files = []
+    for f in os.listdir('.'):
+        if os.path.isfile(f):
+            files.append(f)
+    options = []
+    for i, file in enumerate(files, start=1):
+        options.append(f"[{i}] {file}")
+    options.append("[b] Back to Main Menu")
+    
+    def preview_command(file):
+        """Function to preview the contents of a file."""
+        try:
+            with open(file, 'r') as f:
+                return f.read()
+        except Exception:
+            return ""  # Return an empty string if the file can't be read
+
+    terminal_menu = TerminalMenu(options, menu_cursor_style=('fg_red', 'bold'), menu_highlight_style=('bg_green', 'bold'), preview_command=preview_command)
+    menu_entry_index = terminal_menu.show()
+    if menu_entry_index == len(options) - 1:
+        main_menu()
+    else:
+        selected_file = files[menu_entry_index]
+        run_ansible_playbook(selected_file)
+
+def run_ansible_playbook(file):
+    """Function to run ansible-playbook with the selected file and arguments."""
+    args = input("Enter any additional arguments for ansible-playbook: ")
+    command = f"ansible-playbook {file} {args}"
+    try:
+        subprocess.run(command, shell=True)
+    except Exception as e:
+        print(f"Failed to run ansible-playbook: {e}")
     main_menu()
 
 def clear_screen():

--- a/models.py
+++ b/models.py
@@ -3,7 +3,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
 Base = declarative_base()
-engine = create_engine('sqlite:///hosts.db')
+engine = create_engine('sqlite:///poc_helper.db')
 Session = sessionmaker(bind=engine)
 session = Session()
 
@@ -16,5 +16,14 @@ class Host(Base):
     connection = Column(String, nullable=False)
     username = Column(String, nullable=False)
     password = Column(String, nullable=False)
+    image_type = Column(String, nullable=False)
+
+class Link(Base):
+    __tablename__ = 'links'
+    id = Column(Integer, primary_key=True)
+    source_host = Column(String, nullable=False)
+    source_interface = Column(String, nullable=False)
+    destination_host = Column(String, nullable=False)
+    destination_interface = Column(String, nullable=False)
 
 Base.metadata.create_all(engine)

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy import create_engine, Column, Integer, String, Float
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
@@ -25,5 +25,11 @@ class Link(Base):
     source_interface = Column(String, nullable=False)
     destination_host = Column(String, nullable=False)
     destination_interface = Column(String, nullable=False)
+    jitter = Column(Integer, default=0, nullable=False)
+    latency = Column(Integer, default=0, nullable=False)
+    loss = Column(Integer, default=0, nullable=False)
+    rate = Column(Integer, default=0, nullable=False)
+    corruption = Column(Integer, default=0, nullable=False)
+    state = Column(String, default='enabled', nullable=False)
 
 Base.metadata.create_all(engine)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyYAML==6.0.2
 simple-term-menu==1.6.6
 SQLAlchemy==2.0.36
 typing_extensions==4.12.2
+tabulate==0.9.0


### PR DESCRIPTION
Add functionality to import and display hosts and links. Add interface impairment and enable/disable. Updated database schema.
- Updated `models.py` to include `image_type` column in `Host` model and created `Link` model.
- Updated `import_links_from_containerlab` function to parse `topology.yml` and add links to the database.
- Updated `import_inv_from_yaml` function to parse group names for `network_os` and `image_type`, and print a table of hosts added.
- Added `import_inv_from_ini` function to parse INI inventory files and print a table of hosts added.
- Added `tabulate` library to `requirements.txt` for table formatting.
- Created `.gitignore` to exclude `__pycache__` and `cenv` folders.
- Added default file search for ansible-inventory.yml, ini and topology.yml
- Added functionality to impair network interfaces with delay, jitter, packet loss, rate limiting, and packet corruption.
- Created a new sub-menu under "Interface Management" for "Impair Interfaces".
- Displayed a tabular list of all links with their current non-zero impairment values.
- Allowed users to select a link and either remove impairments or set new impairment values.
- Ensured jitter and delay are always set together.
- Updated the `apply_impairments` function to run the `containerlab tools netem set` command with `sudo`.
- Updated the `README.md` to reflect the new features and usage instructions.
- Updated the `models.py` to include new columns in the `Link` model: `jitter`, `latency`, `loss`, `rate`, and `corruption`.
- Ensured the database schema is updated to include the new columns.